### PR TITLE
set compatibility how to get swap memory for get_memory_maps() in OS X

### DIFF
--- a/mrq/worker.py
+++ b/mrq/worker.py
@@ -192,7 +192,7 @@ class Worker(object):
         mmaps = self.process.get_memory_maps()
         mem = {
             "rss": sum([x.rss for x in mmaps]),
-            "swap": sum([x.swap for x in mmaps])
+            "swap": sum([getattr(x, 'swap', getattr(x, 'swapped')) for x in mmaps])
         }
         mem["total"] = mem["rss"] + mem["swap"]
         return mem


### PR DESCRIPTION
Hi, in my laptop (OS X) i got error:
```
2015-04-10 03:11:05,240 DEBG 'mrq-worker0' stderr output:
    
  File "/Users/ayik/Repositories/python/mrq/mrq/worker.py", line 351, in work
    return self.work_stop()
  File "/Users/ayik/Repositories/python/mrq/mrq/worker.py", line 456, in work_stop
    self.report_worker(w=1)
  File "/Users/ayik/Repositories/python/mrq/mrq/worker.py", line 295, in report_worker
    report = self.get_worker_report()
  File "/Users/ayik/Repositories/python/mrq/mrq/worker.py", line 248, in get_worker_report
    mem = self.get_memory()
  File "/Users/ayik/Repositories/python/mrq/mrq/worker.py", line 195, in get_memory
    "swap": sum([x.swap for x in mmaps])
AttributeError: 'mmap' object has no attribute 'swap'
```
In OS X, swap memory is using attribute "swapped" instead of "swap". So, I think it could be simply resolved using this pull request. It's just one line change, and should pass tests, hopefully :D sorry, i didn't test it since it needed to setup docker, which i don't have right now