### PR TITLE
Removed useless print statement

### DIFF
--- a/mrq/scheduler.py
+++ b/mrq/scheduler.py
@@ -12,7 +12,7 @@ def _hash_task(task):
 
     full = [str(task.get(x)) for x in ["path", "interval", "dailytime", "queue"]]
 
-    print full.extend([str(params)])
+    full.extend([str(params)])
     return " ".join(full)
 
 


### PR DESCRIPTION
I don't think there is a reason to print none when extending full.