### PR TITLE
Fix 'disabled' auto-refresh option

### DIFF
--- a/mrq/dashboard/static/js/views/index.js
+++ b/mrq/dashboard/static/js/views/index.js
@@ -107,27 +107,35 @@ define(["jquery", "underscore", "views/generic/page", "models", "moment", "circl
     refreshStats: function (poolSize, currentJobs, utilization, doneJobs) {
       var self = this;
       var values = self.addToCounter("overall-done-jobs", doneJobs, 50).join(",");
-      var refreshInterval = parseInt($(".js-autorefresh").val(), 10) * 1000;
 
       self.$(".inlinesparkline").attr("values", values);
       self.$(".inlinesparkline").sparkline("html", {"width": "250px", "height": "200px", "defaultPixelsPerValue": 1});
       self.refreshCircleStats(poolSize, currentJobs, utilization);
-
-      setTimeout(function () {
-        self.fetchStats(self.refreshStats);
-      }, refreshInterval);
+      self.autoUpdateStats();
     },
 
     render: function() {
       var self = this;
-      var refreshInterval = parseInt($(".js-autorefresh").val(), 10) * 1000;
 
       self.renderTemplate();
       self.fetchStats(self.renderStats);
+      self.autoUpdateStats();
+    },
 
-      setTimeout(function () {
-        self.fetchStats(self.refreshStats);
-      }, refreshInterval);
+    autoUpdateStats: function() {
+      var self = this;
+      var refreshInterval = parseInt($(".js-autorefresh").val(), 10) * 1000;
+
+      if(refreshInterval > 0) {
+        setTimeout(function () {
+          self.fetchStats(self.refreshStats);
+        }, refreshInterval);
+      } else {
+        // Check if the option has changed again in 2 seconds
+        setTimeout(function () {
+          self.autoUpdateStats();
+        }, 2000);
+      }
     }
 
   });

--- a/mrq/dashboard/templates/index.html
+++ b/mrq/dashboard/templates/index.html
@@ -78,7 +78,7 @@
               <option value="60">1m</option>
               <option value="300">5m</option>
               <option value="600">10m</option>
-              <option value="0">Disabled</option>
+              <option value="-1">Disabled</option>
             </select></a>
             </li>
 


### PR DESCRIPTION
Fixes #100 by refactoring setting the refresh timeouts and makes the 'disabled' option a -1 value. Allows us to detect it being different from any actual internal and disables the calls to the API. Decided a 2 second timeout between checks for the option being changed was probably sufficient for now. Thanks!