### PR TITLE
Store k-v from config file in 'from_file' dict

### DIFF
--- a/mrq/config.py
+++ b/mrq/config.py
@@ -438,7 +438,7 @@ def get_config(
 
             # We only keep variables starting with an uppercase character.
             if k[0].isupper():
-                default_config[k.lower()] = v
+                from_file[k.lower()] = v
 
     # Merge the config in the order given by the user
     merged_config = default_config


### PR DESCRIPTION
This prevents key value pairs parsed from config file from leaking into 'default_config'.
Those key value pairs stored in 'from_file' will eventually be merged into 'merged_config'.

And it seems that the merging logic will have the settings from the configuration file overwrite the same settings specified by the environment variable and the arguments.