### PR TITLE
A potential fix for 'used_pool_slots'

### DIFF
--- a/mrq/worker.py
+++ b/mrq/worker.py
@@ -306,7 +306,7 @@ class Worker(object):
                 else:
                     io[k] = sorted(v.items(), reverse=True, key=lambda x: x[1])
 
-        used_pool_slots = self.gevent_pool.free_count() - self.pool_size
+        used_pool_slots = self.pool_size - self.gevent_pool.free_count()
 
         return {
             "status": self.status,


### PR DESCRIPTION
I think the order of substraction in the existing code should be reversed when counting 'used_pool_slots'