### PR TITLE
Fix encoding error (python 3)

### DIFF
--- a/mrq/queue.py
+++ b/mrq/queue.py
@@ -168,7 +168,7 @@ class Queue(object):
         if len(job_ids) == 0 or self.use_large_ids:
             return job_ids
         else:
-            return [binascii.hexlify(x).decode('ascii') for x in job_ids]
+            return [binascii.hexlify(x.encode('utf-8') if isinstance(x, str) else x).decode('ascii') for x in job_ids]
 
     def _get_pausable_id(self):
       """


### PR DESCRIPTION
BTW we now use MRQ successfully in production with python 3.5.2 at Serenytics :)
Thanks again @sylvinus for sharing this lib! 