### PR TITLE
Locking down redis version to 2.10.5

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,5 +1,5 @@
 argparse>=1.1
-redis>=2.10.5
+redis==2.10.5
 pymongo>=3.0.1
 gevent>=1.2.2
 ujson>=1.33


### PR DESCRIPTION
Updating requirements.txt to prevent issues with LuaLock caused by new redis client version