### PR TITLE
fixed typo in docs

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -46,7 +46,7 @@ You can pass additional configuration flags:
  - `--max_jobs`: Gevent:max number of jobs to do before quitting. Use as a workaround for memory leaks in your tasks. Defaults to **0**
  - `--max_memory`: Max memory (in Mb) after which the process will be shut down. Use with `--processes [1-N]`
                   to have the worker automatically respawn when this happens. Defaults to **1**
- - `--grenlets, --gevent, --g`: Max number of greenlets to use. Defaults to **1**.
+ - `--greenlets, --gevent, --g`: Max number of greenlets to use. Defaults to **1**.
  - `--processes, --p`: Number of processes to launch . Defaults to **0**.
  - `--scheduler`: Run the scheduler. Defaults to **false**.
  - `--scheduler_interval`: Seconds between scheduler checks. Defaults to **60** seconds, only ints are acceptable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ QUEUES = ("default",) # The queues to listen on.Defaults to default , which will
 MAX_JOBS = 0 #Gevent:max number of jobs to do before quitting. Workaround for memory leaks in your tasks. Defaults to 0
 MAX_TIME = 0 # max number of seconds a worker runs before quitting
 MAX_MEMORY = 1 #Max memory (in Mb) after which the process will be shut down. Use with PROCESS = [1-N] to have the worker automatically respawned when this happens.Defaults to 1
-GRENLETS = 1 #Max number of greenlets to use.Defaults to 1.
+GREENLETS = 1 #Max number of greenlets to use.Defaults to 1.
 PROCESSES = 0 #Number of processes to launch.Defaults to 0.
 SCHEDULER = False #Run the scheduler.Defaults to False.
 SCHEDULER_INTERVAL = 60 #Seconds between scheduler checks.Defaults to 60 seconds, only ints are acceptable.


### PR DESCRIPTION
Greenlets instead of grenlets - can be confusing especially in cli/env configurations