### PR TITLE
Update to support renaming of LuaLock to Lock in redis-py

### DIFF
--- a/mrq/agent.py
+++ b/mrq/agent.py
@@ -8,7 +8,12 @@ import shlex
 import traceback
 from collections import defaultdict
 from bson import ObjectId
-from redis.lock import LuaLock
+
+try:
+    from redis.lock import LuaLock
+except ImportError:
+    from redis.lock import Lock
+    
 from .processes import Process, ProcessPool
 from .utils import MovingETA, normalize_command
 from .queue import Queue

--- a/mrq/worker.py
+++ b/mrq/worker.py
@@ -15,7 +15,12 @@ import sys
 import json as json_stdlib
 import ujson as json
 from bson import ObjectId
-from redis.lock import LuaLock
+
+try:
+    from redis.lock import LuaLock
+except ImportError:
+    from redis.lock import Lock
+    
 from collections import defaultdict
 from mrq.utils import load_class_by_path
 


### PR DESCRIPTION
This patch keeps backsward compatibility with old versions of redis-py by importing old name before, then the new one.