### PR TITLE
Fix iterating keys for python3

### DIFF
--- a/mrq/basetasks/utils.py
+++ b/mrq/basetasks/utils.py
@@ -154,6 +154,6 @@ class JobAction(Task):
                         "_id": {"$in": jobs_by_queue[queue]}
                     }, {"$set": updates}, multi=True)
 
-                set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.iteritems()})
+                set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.items()})
 
         return stats


### PR DESCRIPTION
Hello,

I'm fixing the following error:

```
File "/usr/local/src/mrq/mrq/worker.py", line 671, in perform_job
    job.perform()
  File "/usr/local/src/mrq/mrq/job.py", line 307, in perform
    result = self.task.run_wrapped(self.data["params"])
  File "/usr/local/src/mrq/mrq/task.py", line 20, in run_wrapped
    return self.run(params)
  File "/usr/local/src/mrq/mrq/basetasks/cleaning.py", line 19, in run
    "action": "requeue_retry"
  File "/usr/local/src/mrq/mrq/context.py", line 232, in run_task
    return task_class().run_wrapped(params)
  File "/usr/local/src/mrq/mrq/task.py", line 20, in run_wrapped
    return self.run(params)
  File "/usr/local/src/mrq/mrq/basetasks/utils.py", line 32, in run
    self.params.get("action"), query, self.params.get("destination_queue")
  File "/usr/local/src/mrq/mrq/basetasks/utils.py", line 157, in perform_action
    set_queues_size({queue: len(jobs) for queue, jobs in jobs_by_queue.iteritems()})
AttributeError: 'collections.defaultdict' object has no attribute 'iteritems'
```