### PR TITLE
can not get redis password on win10

### DIFF
--- a/mrq/context.py
+++ b/mrq/context.py
@@ -150,7 +150,7 @@ def _connections_factory(attr):
                 host=redis_url.hostname,
                 port=redis_url.port,
                 db=int((redis_url.path or "").replace("/", "") or "0"),
-                password=redis_url.password,
+                password=redis_url.password or redis_url.netloc.split("@")[0],
                 max_connections=int(config.get("redis_max_connections")),
                 timeout=int(config.get("redis_timeout")),
                 decode_responses=False


### PR DESCRIPTION
Traceback (most recent call last):
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\Scripts\mrq-run-script.py", line 11, in <module>
    load_entry_point('mrq==0.9.10', 'console_scripts', 'mrq-run')()
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\mrq-0.9.10-py3.7.egg\mrq\bin\mrq_run.py", line 53, in main
    ret = queue_job(cfg["taskpath"], params, queue=cfg["queue"])
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\mrq-0.9.10-py3.7.egg\mrq\job.py", line 674, in queue_job
    return queue_jobs(main_task_path, [params], **kwargs)[0]
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\mrq-0.9.10-py3.7.egg\mrq\job.py", line 718, in queue_jobs
    set_queues_size({queue: len(all_ids)})
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\mrq-0.9.10-py3.7.egg\mrq\job.py", line 684, in set_queues_size
    pipe.execute()
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\redis-2.10.6-py3.7.egg\redis\client.py", line 2879, in execute
    return execute(conn, stack, raise_on_error)
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\redis-2.10.6-py3.7.egg\redis\client.py", line 2810, in _execute_pipeline
    connection.send_packed_command(all_cmds)
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\redis-2.10.6-py3.7.egg\redis\connection.py", line 585, in send_packed_command
    self.connect()
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\redis-2.10.6-py3.7.egg\redis\connection.py", line 493, in connect
    self.on_connect()
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\redis-2.10.6-py3.7.egg\redis\connection.py", line 567, in on_connect
    if nativestr(self.read_response()) != 'OK':
  File "C:\Users\cuijianxiong\AppData\Local\Programs\Python\Python37\lib\site-packages\redis-2.10.6-py3.7.egg\redis\connection.py", line 629, in read_response
    raise response
redis.exceptions.ResponseError: NOAUTH Authentication required.