### PR TITLE
Avoid NameError when Lock is used in place of LuaLock

### DIFF
--- a/mrq/agent.py
+++ b/mrq/agent.py
@@ -12,7 +12,8 @@ from bson import ObjectId
 try:
     from redis.lock import LuaLock
 except ImportError:
-    from redis.lock import Lock
+    # Change name to avoid NameError raised when use of LuaLock at line 147
+    from redis.lock import Lock as LuaLock
     
 from .processes import Process, ProcessPool
 from .utils import MovingETA, normalize_command

--- a/mrq/worker.py
+++ b/mrq/worker.py
@@ -19,7 +19,8 @@ from bson import ObjectId
 try:
     from redis.lock import LuaLock
 except ImportError:
-    from redis.lock import Lock
+    # Change name to avoid NameError raised when use of LuaLock at line 151
+    from redis.lock import Lock as LuaLock
     
 from collections import defaultdict
 from mrq.utils import load_class_by_path


### PR DESCRIPTION
The change made for avoid ImportError with LuaLock generates a NameError when the object is used.
To avoid the NameError, use the Lock object in place of LuaLock object or rename the Lock import as LuaLock.

Regards,