### PR TITLE
docs: fix simple typo, instanciate -> instantiate

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -103,7 +103,7 @@ A regular Python logging object that should be used in your task code. It will m
 
 * `connections`
 
-A lazy-loaded object containing the worker's connections to MongoDB and Redis. You can implement your own connection factories to instanciate other services lazily.
+A lazy-loaded object containing the worker's connections to MongoDB and Redis. You can implement your own connection factories to instantiate other services lazily.
 
 * `run_task(path, params)`
 


### PR DESCRIPTION
There is a small typo in docs/jobs.md.

Should read `instantiate` rather than `instanciate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md